### PR TITLE
add read function

### DIFF
--- a/lib/params_builder.rb
+++ b/lib/params_builder.rb
@@ -22,4 +22,12 @@ module ParamsBuilder
       )
     ).first
   end
+
+  def self.read(file_name)
+    path = "#{config.file_path}/#{file_name}.yml.erb"
+
+    YAML.load_stream(
+      ERB.new(File.read(path)).result
+    ).first
+  end
 end

--- a/params_builders/user_params.yml.erb
+++ b/params_builders/user_params.yml.erb
@@ -1,0 +1,6 @@
+name: "john"
+logo: "logo"
+owner: "owner"
+images_attributes:
+  - url: "a.jpg"
+  - url: "b.jpg"

--- a/spec/params_builder_spec.rb
+++ b/spec/params_builder_spec.rb
@@ -25,4 +25,25 @@ describe ParamsBuilder do
       ParamsBuilder.build(:company_params, owner: owner, company: company)
     ).to eq company_params.deep_stringify_keys
   end
+
+  it "read without params" do
+    user_params = {
+      name: "john",
+      logo: "logo",
+      owner: "owner",
+
+      images_attributes: [
+        {
+          url: "a.jpg"
+        },
+        {
+          url: "b.jpg"
+        }
+      ]
+    }
+
+    expect(
+      ParamsBuilder.read(:user_params)
+    ).to eq user_params.deep_stringify_keys
+  end
 end


### PR DESCRIPTION
Thanks for amazing `params_builder` which make my life easier!

But I found that it can't be use to read a yml file without params.
So I think it is good to add `read` function to implement it.
